### PR TITLE
Add Dockerfile and docker compose support, Closes #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.23.2-alpine3.20
+
+WORKDIR /pasta
+
+COPY go.mod ./
+COPY main.go ./
+
+RUN go build -o pasta
+
+EXPOSE 8080
+EXPOSE 80
+
+CMD ["./pasta"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The docker container can be started either using the `docker run` command or usi
 #### docker run
 ```
 docker build -t pasta:latest .
-docker run -d -p 8080:8080 pasta
+docker run -d -p 8080:8080 pasta:latest
 ```
 
 #### docker-compose

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ $ curl -F "file=@file.txt" "localhost:8080"
 go install codeberg.org/polarhive/pasta@latest
 ```
 
+### docker usage
+
+The docker container can be started either using the `docker run` command or using the `docker-compose.yml` file included.
+
+#### docker run
+```
+docker build -t pasta:latest .
+docker run -d -p 8080:8080 pasta
+```
+
+#### docker-compose
+```
+docker-compose build
+docker-compose up
+```
+
 ### limitations
 
 I set it up on my server for my personal use. [Ping](https://polarhive.net/contact) me if you wish to use my resources (no spam lol)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   pasta:
     build: .
     ports:
-      - "${PASTA_PORT}:8080"
+      - "${PASTA_PORT:-8080}:8080"
       - "80:80"
     # volumes:
     # - ./data:/data Uncomment if you want to have local access to the data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  pasta:
+    build: .
+    ports:
+      - "${PASTA_PORT}:8080"
+      - "80:80"
+    # volumes:
+    # - ./data:/data Uncomment if you want to have local access to the data
+    environment:
+      - PASTA_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
   pasta:
     build: .
+    restart: unless-stopped
     ports:
       - "${PASTA_PORT:-8080}:8080"
       - "80:80"
     # volumes:
     # - ./data:/data Uncomment if you want to have local access to the data
-    environment:
-      - PASTA_PORT=8080


### PR DESCRIPTION
Added preliminary Docker support using the Golang alpine docker base. It can be started with either `docker run` or using the included docker-compose.yml.